### PR TITLE
@bugfix - inject.js重复添加 + 支持多页面同时调试

### DIFF
--- a/backend/background.js
+++ b/backend/background.js
@@ -20,6 +20,7 @@ chrome.runtime.onConnect.addListener(function(connection) {
         chrome.tabs.onUpdated.addListener(function(tabId, changeInfo) {
             if (changeInfo.status === "complete") {
                 console.log(prefix + "Backend send pageReload event");
+
                 devToBackConnection.postMessage({
                     type: "pageReload",
                     tabId: tabId

--- a/backend/background.js
+++ b/backend/background.js
@@ -1,44 +1,52 @@
 // background.js, runs presistently
 // inject content script for devtools page
 // pass message from content script to devtools page
-var devToBackConnection;
-var injectToBackConnection;
 var prefix = "[Regular Devtools] ";
+var injectToBackConnection;
+
+// for every page's different injectToBackConnection to its devToBackConnection  according to tab.id
+var devToBackConMap = {};
+
+
+var injectListener = function(message, sender, sendResponse) {
+    // Inject a content script into the identified tab
+    chrome.tabs.executeScript(message.tabId, {
+        file: message.file
+    });
+    console.log(prefix + "Content script injected.");
+};
+
+// cannot put in onConnect.addListener() for everyConnect add one  callbackFun
+chrome.tabs.onUpdated.addListener(function(tabId, changeInfo) {
+    if (changeInfo.status === "complete") {
+        console.log(prefix + "Backend send pageReload event");
+
+        devToBackConMap[tabId].postMessage({
+            type: "pageReload",
+            tabId: tabId
+        })
+    }
+});
 
 chrome.runtime.onConnect.addListener(function(connection) {
-    var injectListener = function(message, sender, sendResponse) {
-            // Inject a content script into the identified tab
-            chrome.tabs.executeScript(message.tabId, {
-                file: message.file
-            });
-            console.log(prefix + "Content script injected.");
-        }
-        // add the listener
-    if (connection.name == "devToBackCon") {
-        devToBackConnection = connection;
-        devToBackConnection.onMessage.addListener(injectListener);
-        chrome.tabs.onUpdated.addListener(function(tabId, changeInfo) {
-            if (changeInfo.status === "complete") {
-                console.log(prefix + "Backend send pageReload event");
 
-                devToBackConnection.postMessage({
-                    type: "pageReload",
-                    tabId: tabId
-                })
-            }
-        })
+    // add the listener
+    if (connection.name.indexOf("devToBackCon") != -1) {
+        var tabId = connection.name.split('_')[1];
+        console.log("dev2Back get connect with tabId: "+ tabId);
+        devToBackConMap[tabId] = connection;
+        devToBackConMap[tabId].onMessage.addListener(injectListener);
         return;
     }
 
-    // Receive message from content script and relay to the devTools page for the
-    // current tab
+    // Receive message from content script and relay to its devTools page according sender  tab.id
     if (connection.name === "injectToBackCon") {
-        injectToBackConnection = null;
         injectToBackConnection = connection;
         console.log(prefix + "injectToBack Connection established.", connection)
         injectToBackConnection.onMessage.addListener(function(request, sender, sendResponse) {
             console.log(prefix + "Backend received message:" + request.type)
-            devToBackConnection.postMessage(request);
+            console.log("inject2Back sent info with tabId: "+ sender.sender.tab.id);
+            devToBackConMap[sender.sender.tab.id].postMessage(request);
             return true;
         });
     }

--- a/devtools.js
+++ b/devtools.js
@@ -6,9 +6,10 @@ var backgroundPageConnection = chrome.runtime.connect({
     name: "devToBackCon"
 });
 
-var injectContentScript = function() {
+
+var injectContentScript = function(tabId) {
     backgroundPageConnection.postMessage({
-        tabId: chrome.devtools.inspectedWindow.tabId,
+        tabId: tabId || chrome.devtools.inspectedWindow.tabId,
         file: "/frontend/content.js"
     });
 }
@@ -338,10 +339,12 @@ devtools
             path[0].data.selected = true;
             elementView.$update();
         }
-    }).$on("reload", function() {
+    }).$on("reload", function(event) {
         console.log(prefix + "On reload.");
         // wait for the page to fully intialize
-        setTimeout(injectContentScript, 2000);
+        setTimeout(function(){
+            injectContentScript(event.tabId);
+        }, 2000);
     })
 
 backgroundPageConnection.onMessage.addListener(function(message) {
@@ -354,7 +357,9 @@ backgroundPageConnection.onMessage.addListener(function(message) {
     } else if (message.type === "pageReload") {
         elementView.data.loading = true;
         elementView.$update();
-        devtools.$emit("reload");
+        devtools.$emit("reload",{
+            tabId: message.tabId
+        });
     }
 });
 

--- a/devtools.js
+++ b/devtools.js
@@ -1,9 +1,9 @@
 // the real devtools script
 // the UI layer of devtools
 
-// Create a connection to the background page
+// Create a current inspected page unique connection to the background page, by its tabId
 var backgroundPageConnection = chrome.runtime.connect({
-    name: "devToBackCon"
+    name: "devToBackCon_" + chrome.devtools.inspectedWindow.tabId
 });
 
 

--- a/frontend/content.js
+++ b/frontend/content.js
@@ -1,5 +1,6 @@
 // this is the content script runs when the panel is activated.
 // this script serves as the brigde between app page script(inject and hook) and the backend script 
+
 var port = chrome.runtime.connect({
     name: "injectToBackCon"
 });


### PR DESCRIPTION
1. 解决： 页面中重复添加inject.js文件，导致重复添加监听函数,重复渲染的性能问题
2. 解决： 无法开启多页面同时调试，引入tabId, 标识background.js中的connection,对应的contentScript与devtools panel 之前通信
